### PR TITLE
Feat: Comment Dto 추가 및 Comment 모델 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/dto/CommentDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/dto/CommentDto.kt
@@ -1,0 +1,24 @@
+package com.wafflestudio.waffleoverflow.domain.comment.dto
+
+import com.wafflestudio.waffleoverflow.domain.comment.model.Comment
+import com.wafflestudio.waffleoverflow.domain.user.dto.UserDto
+
+class CommentDto (
+
+    ){
+    data class Wrapper(
+        val id: Long,
+        val user: UserDto.Response,
+        val body: String,
+        val questionId: Long?,
+        val answerId: Long?,
+    ) {
+        constructor(comment: Comment) : this(
+            comment.id,
+            UserDto.Response(comment.user),
+            comment.body,
+            comment.question?.id,
+            comment.answer?.id
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/dto/CommentDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/dto/CommentDto.kt
@@ -3,9 +3,7 @@ package com.wafflestudio.waffleoverflow.domain.comment.dto
 import com.wafflestudio.waffleoverflow.domain.comment.model.Comment
 import com.wafflestudio.waffleoverflow.domain.user.dto.UserDto
 
-class CommentDto (
-
-    ){
+class CommentDto {
     data class Wrapper(
         val id: Long,
         val user: UserDto.Response,

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/dto/CommentDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/dto/CommentDto.kt
@@ -4,7 +4,7 @@ import com.wafflestudio.waffleoverflow.domain.comment.model.Comment
 import com.wafflestudio.waffleoverflow.domain.user.dto.UserDto
 
 class CommentDto {
-    data class Wrapper(
+    data class Response(
         val id: Long,
         val user: UserDto.Response,
         val body: String,

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/model/Comment.kt
@@ -26,4 +26,3 @@ class Comment(
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     val answer: Answer? = null,
 ) : BaseTimeEntity()
-

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/model/Comment.kt
@@ -9,12 +9,16 @@ import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.ManyToOne
 import javax.persistence.Table
+import javax.validation.constraints.NotBlank
 
 @Entity
 @Table(name = "comment")
 class Comment(
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-    val user: User? = null,
+    val user: User,
+
+    @NotBlank
+    val body: String,
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     val question: Question? = null,
@@ -22,3 +26,4 @@ class Comment(
     @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     val answer: Answer? = null,
 ) : BaseTimeEntity()
+


### PR DESCRIPTION
### 개요
Question과 Answer의 Response에 Comment가 전부 포함되기 때문에, 코드 재사용과 편의를 위해 Comment Dto를 추가하였습니다. 이 과정에서 Comment 모델을 일부 변경하였습니다.

### 추가된 내용
#### Comment.kt
- `Comment.body` 추가
- `Comment.user`의 타입을 `User?`에서 `User`로 변경. 이는 구현 로직상 애초에 null이 들어가면 안된다고 생각했습니다.
#### CommentDto.kt
- `CommentDto.Wrapper` 추가 (API docs의 기본 nested response 용 Dto입니다)