### PR TITLE
Fix: pingpong config (anonymous -> permitAll)

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/global/config/SecurityConfig.kt
@@ -77,7 +77,7 @@ class SecurityConfig(
             .authorizeRequests()
             .antMatchers("/api/user/signin/").permitAll()
             .antMatchers(HttpMethod.POST, "/api/user/signup/").anonymous()
-            .antMatchers(HttpMethod.GET, "/api/ping/").anonymous()
+            .antMatchers(HttpMethod.GET, "/api/ping/").permitAll()
             .antMatchers(HttpMethod.GET, "/api/question/**").permitAll()
             .anyRequest().authenticated()
     }


### PR DESCRIPTION
- anonymous로 설정하면 로그인이 안 된 유저에게만 허용되기 때문에, 로그인 이후에는 403 forbidden이 뜨는 문제가 있습니다.
- permitAll로 설정하여 해결하였습니다.