### PR TITLE
Conf: answer API (GET: permitAll)

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/global/config/SecurityConfig.kt
@@ -79,6 +79,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/api/user/signup/").anonymous()
             .antMatchers(HttpMethod.GET, "/api/ping/").permitAll()
             .antMatchers(HttpMethod.GET, "/api/question/**").permitAll()
+            .antMatchers(HttpMethod.GET, "/api/answer/**").permitAll()
             .anyRequest().authenticated()
     }
 


### PR DESCRIPTION
- Answer API도 비로그인 사용자의 이용이 필요하므로 GET api들의 설정을 permitAll로 바꾸었습니다.