### PR TITLE
Fix/sprint4 errors

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/answer/dto/AnswerDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/answer/dto/AnswerDto.kt
@@ -38,10 +38,14 @@ class AnswerDto {
     data class ResponseSummary(
         val id: Long,
         val questionTitle: String,
+        val questionId: Long,
+        val createdAt: LocalDateTime?
     ) {
         constructor(answer: Answer) : this(
             id = answer.id,
             questionTitle = answer.question.title,
+            questionId = answer.question.id,
+            createdAt = answer.createdAt
         )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/exception/TooLongCommentException.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/exception/TooLongCommentException.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.waffleoverflow.domain.comment.exception
+
+import com.wafflestudio.waffleoverflow.global.common.exception.ErrorType
+import com.wafflestudio.waffleoverflow.global.common.exception.InvalidRequestException
+
+class TooLongCommentException(detail: String) : InvalidRequestException(errorType = ErrorType.BAD_REQUEST, detail)

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/dto/QuestionDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/dto/QuestionDto.kt
@@ -46,10 +46,12 @@ class QuestionDto {
     data class ResponseSummary(
         val id: Long,
         val title: String,
+        val createdAt: LocalDateTime?
     ) {
         constructor(question: Question) : this(
             id = question.id,
             title = question.title,
+            createdAt = question.createdAt,
         )
     }
 }


### PR DESCRIPTION
Sprint4에서 발생한 일부 문제들을 해결하였습니다.

- 길이 제한 초과하는 comment 추가시 500 error이 나오는 문제
  - 250자 초과시 에러 메시지를 띄우도록 변경하였습니다.

- DTO에 정보 추가
  - QuestionSummary에 createdAt 추가
  - AnswerSummary에 questionId, createdAt 추가