### PR TITLE
Fix: add voteCount column to Question model

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/answer/model/Answer.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/answer/model/Answer.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.waffleoverflow.domain.model.BaseTimeEntity
 import com.wafflestudio.waffleoverflow.domain.question.model.Question
 import com.wafflestudio.waffleoverflow.domain.user.model.User
 import com.wafflestudio.waffleoverflow.domain.vote.model.Vote
+import com.wafflestudio.waffleoverflow.domain.vote.model.VoteStatus
 import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -24,6 +25,8 @@ class Answer(
 
     @OneToMany(mappedBy = "answer", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
     var votes: MutableList<Vote> = mutableListOf(),
+
+    var voteCount: Int = votes.count { it.status == VoteStatus.UP } - votes.count { it.status == VoteStatus.DOWN },
 
     @OneToMany(mappedBy = "answer", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
     var comments: MutableList<Comment> = mutableListOf(),

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/model/Question.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/model/Question.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.waffleoverflow.domain.comment.model.Comment
 import com.wafflestudio.waffleoverflow.domain.model.BaseTimeEntity
 import com.wafflestudio.waffleoverflow.domain.user.model.User
 import com.wafflestudio.waffleoverflow.domain.vote.model.Vote
+import com.wafflestudio.waffleoverflow.domain.vote.model.VoteStatus
 import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -25,6 +26,8 @@ class Question(
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
     var votes: MutableList<Vote> = mutableListOf(),
+
+    var voteCount: Int = votes.count { it.status == VoteStatus.UP } - votes.count { it.status == VoteStatus.DOWN },
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
     var comments: MutableList<Comment> = mutableListOf(),


### PR DESCRIPTION
슬랙에 썼던 내용 반복입니다!

- 요약: Question 모델에 필드를 하나 더 추가하려고 합니다.

- 백엔드 오류 중에 Vote 기준으로 정렬시 중복된 Questions가 뜨는 문제가 있었습니다. (`GET api/question?&sort=vote,desc`)
  - 확인해보니, 현재 프로젝트 Vote의 구조 때문이었습니다.
  - 현재 하나의 Question에 여러 개의 Vote 객체들이 리스트로 저장된 구조라서, Vote를 기준으로 정렬하게 되면 당연한 결과였습니다.
  - 그런데 현재 상태로는 Vote Count를 기준으로 정렬된 결과를 전달할 방법이 보이지 않아, 해당 필드를 추가해야 할 것 같습니다.

- 혹시 문제가 있어 보이거나 더 나은 해결책이 있는 것 같다면 말씀해주세요!