### PR TITLE
Edit User API 생성

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/api/UserController.kt
@@ -10,6 +10,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -76,6 +77,16 @@ class UserController(
     ): UserDto.Response {
         val thisUser = userService.editProfileImage(user, multipartFile)
         return UserDto.Response(thisUser)
+    }
+
+    @PatchMapping("/me/edit/")
+    @ResponseStatus(HttpStatus.OK)
+    fun editProfile(
+        @CurrentUser user: User,
+        @Valid @RequestBody editProfileRequest: UserDto.EditProfileRequest,
+    ): UserDto.Response {
+        val editUser = userService.editUserProfile(user, editProfileRequest)
+        return UserDto.Response(editUser)
     }
 
     @DeleteMapping("/me/remove/")

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/api/UserController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/api/UserController.kt
@@ -10,7 +10,6 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -79,7 +78,7 @@ class UserController(
         return UserDto.Response(thisUser)
     }
 
-    @PatchMapping("/me/edit/")
+    @PutMapping("/me/edit/")
     @ResponseStatus(HttpStatus.OK)
     fun editProfile(
         @CurrentUser user: User,

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
@@ -13,7 +13,12 @@ class UserDto {
         val accessToken: String,
         val image: String?,
         val questions: List<QuestionDto.ResponseSummary>,
-        val answers: List<AnswerDto.ResponseSummary>
+        val answers: List<AnswerDto.ResponseSummary>,
+        val location: String?,
+        val userTitle: String?,
+        val aboutMe: String?,
+        val websiteLink: String?,
+        val githubLink: String?,
     ) {
         constructor(user: User) : this(
             id = user.id,
@@ -22,7 +27,12 @@ class UserDto {
             accessToken = user.accessToken,
             image = user.s3Path,
             questions = user.questions.map { QuestionDto.ResponseSummary(it) },
-            answers = user.answers.map { AnswerDto.ResponseSummary(it) }
+            answers = user.answers.map { AnswerDto.ResponseSummary(it) },
+            location = user.location,
+            userTitle = user.userTitle,
+            aboutMe = user.aboutMe,
+            websiteLink = user.websiteLink,
+            githubLink = user.githubLink,
         )
     }
 
@@ -48,5 +58,13 @@ class UserDto {
 
         @field:NotBlank
         var grantType: String? = "PASSWORD",
+    )
+
+    data class EditProfileRequest(
+        val location: String?,
+        val userTitle: String?,
+        val aboutMe: String?,
+        val websiteLink: String?,
+        val githubLink: String?,
     )
 }

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/exception/EmptyRequestException.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/exception/EmptyRequestException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.waffleoverflow.domain.user.exception
+
+import com.wafflestudio.waffleoverflow.global.common.exception.DataNotFoundException
+import com.wafflestudio.waffleoverflow.global.common.exception.ErrorType
+
+class EmptyRequestException(detail: String = "") :
+    DataNotFoundException(ErrorType.BAD_REQUEST, detail)

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/exception/TooLongUsername.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/exception/TooLongUsername.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.waffleoverflow.domain.user.exception
+
+import com.wafflestudio.waffleoverflow.global.common.exception.ErrorType
+import com.wafflestudio.waffleoverflow.global.common.exception.InvalidRequestException
+
+class TooLongUsername(detail: String = "") :
+    InvalidRequestException(ErrorType.BAD_REQUEST, detail)

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/model/User.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/model/User.kt
@@ -24,7 +24,6 @@ class User(
     @field:NotBlank
     var username: String,
 
-    // @field:NotBlank
     @Column
     var password: String? = null,
 
@@ -35,6 +34,17 @@ class User(
     var accessToken: String,
 
     var s3Path: String? = null,
+
+    var location: String? = null,
+
+    var userTitle: String? = null,
+
+    @Column(columnDefinition = "LONGTEXT")
+    var aboutMe: String? = null,
+
+    var websiteLink: String? = null,
+
+    var githubLink: String? = null,
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
     var questions: MutableList<Question> = mutableListOf(),

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
@@ -63,7 +63,7 @@ class UserService(
         return userRepository.findByEmail(user.email) ?: throw UserNotFoundException()
     }
 
-    fun checkUsernameLength(username: String): Boolean {
+    private fun checkUsernameLength(username: String): Boolean {
         return username.length <= 20
     }
 

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.waffleoverflow.domain.user.service
 
 import com.wafflestudio.waffleoverflow.domain.user.dto.UserDto
 import com.wafflestudio.waffleoverflow.domain.user.exception.BadGrantTypeException
+import com.wafflestudio.waffleoverflow.domain.user.exception.EmptyRequestException
 import com.wafflestudio.waffleoverflow.domain.user.exception.TooLongUsername
 import com.wafflestudio.waffleoverflow.domain.user.exception.UserNotFoundException
 import com.wafflestudio.waffleoverflow.domain.user.exception.UserAlreadyExistsException
@@ -87,6 +88,9 @@ class UserService(
         val aboutMe = editProfileRequest.aboutMe
         val websiteLink = editProfileRequest.websiteLink
         val githubLink = editProfileRequest.githubLink
+
+        if (location == null && userTitle == null && aboutMe == null && websiteLink == null && githubLink == null)
+            throw EmptyRequestException("Empty request.")
 
         if (location != null) user.location = location
         if (userTitle != null) user.userTitle = userTitle

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
@@ -13,9 +13,11 @@ import com.wafflestudio.waffleoverflow.global.auth.jwt.JwtTokenProvider
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 
 @Service
+@Transactional
 class UserService(
     private val userRepository: UserRepository,
     private val passwordEncoder: PasswordEncoder,
@@ -74,5 +76,24 @@ class UserService(
         userRepository.save(user)
 
         return user
+    }
+
+    fun editUserProfile(
+        user: User,
+        editProfileRequest: UserDto.EditProfileRequest,
+    ): User {
+        val location = editProfileRequest.location
+        val userTitle = editProfileRequest.userTitle
+        val aboutMe = editProfileRequest.aboutMe
+        val websiteLink = editProfileRequest.websiteLink
+        val githubLink = editProfileRequest.githubLink
+
+        if (location != null) user.location = location
+        if (userTitle != null) user.userTitle = userTitle
+        if (aboutMe != null) user.aboutMe = aboutMe
+        if (websiteLink != null) user.websiteLink = websiteLink
+        if (githubLink != null) user.githubLink = githubLink
+
+        return userRepository.save(user)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.waffleoverflow.domain.user.service
 
 import com.wafflestudio.waffleoverflow.domain.user.dto.UserDto
 import com.wafflestudio.waffleoverflow.domain.user.exception.BadGrantTypeException
+import com.wafflestudio.waffleoverflow.domain.user.exception.TooLongUsername
 import com.wafflestudio.waffleoverflow.domain.user.exception.UserNotFoundException
 import com.wafflestudio.waffleoverflow.domain.user.exception.UserAlreadyExistsException
 import com.wafflestudio.waffleoverflow.domain.user.exception.UserSignUpBadRequestException
@@ -24,6 +25,7 @@ class UserService(
     fun signup(signupRequest: UserDto.SignupRequest): User {
         if (userRepository.existsUserByUsername(signupRequest.username)) throw UserAlreadyExistsException()
         if (userRepository.existsUserByEmail(signupRequest.email)) throw UserAlreadyExistsException()
+        if (!checkUsernameLength(signupRequest.username)) throw TooLongUsername()
         val user: User?
         val email = signupRequest.email
         val username = signupRequest.username
@@ -56,6 +58,10 @@ class UserService(
 
     fun loadUserInfo(user: User): User {
         return userRepository.findByEmail(user.email) ?: throw UserNotFoundException()
+    }
+
+    fun checkUsernameLength(username: String): Boolean {
+        return username.length <= 20
     }
 
     fun editProfileImage(


### PR DESCRIPTION
- Username 길이를 따져줄 로직을 추가하였습니다.
- Edit User API 생성
  - `location` `userTitle` `aboutMe` `websiteLink` `githubLink` 필드를 추가하여 EditAPI 부분에 넣을 수 있도록 하였습니다.
  - 이에 따라 userResponse 부분도 수정이 있습니다.
  - 또한 프론트에서 `aboutMe`는 마크다운 형식을 적용하기 때문에 LONGTEXT 타입으로 설정하였습니다.
- `UserService.kt`에 `@Transactional` 어노테이션 추가했습니다.