### PR TITLE
Feat/accept cancel

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/api/QuestionController.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/api/QuestionController.kt
@@ -166,9 +166,7 @@ class QuestionController(
         @PathVariable question_id: Long,
         @PathVariable answer_id: Long,
     ): QuestionDto.Response {
-        val question = questionService.findById(question_id)
-        val answer = answerService.findById((answer_id))
-        return questionService.acceptAnswer(user, question, answer)
+        return questionService.acceptAnswer(user, question_id, answer_id)
     }
 
     @GetMapping("/search/{keyword}/")

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/api/QuestionController.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/api/QuestionController.kt
@@ -166,7 +166,9 @@ class QuestionController(
         @PathVariable question_id: Long,
         @PathVariable answer_id: Long,
     ): QuestionDto.Response {
-        return questionService.acceptAnswer(user, question_id, answer_id)
+        val question = questionService.findById(question_id)
+        val answer = answerService.findById(answer_id)
+        return questionService.acceptAnswer(user, question, answer)
     }
 
     @GetMapping("/search/{keyword}/")

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/exception/AcceptedAnswerExistsException.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/exception/AcceptedAnswerExistsException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.waffleoverflow.domain.question.exception
+
+import com.wafflestudio.waffleoverflow.global.common.exception.ErrorType
+import com.wafflestudio.waffleoverflow.global.common.exception.InvalidRequestException
+
+class AcceptedAnswerExistsException(detail: String) :
+    InvalidRequestException(errorType = ErrorType.BAD_REQUEST, detail)

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/exception/AnswerIsNotUnderQuestionException.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/exception/AnswerIsNotUnderQuestionException.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.waffleoverflow.domain.question.exception
+
+import com.wafflestudio.waffleoverflow.global.common.exception.ErrorType
+import com.wafflestudio.waffleoverflow.global.common.exception.InvalidRequestException
+
+class AnswerIsNotUnderQuestionException(detail: String) :
+    InvalidRequestException(errorType = ErrorType.BAD_REQUEST, detail)

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/exception/QuestionNotFoundException.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/exception/QuestionNotFoundException.kt
@@ -3,4 +3,5 @@ package com.wafflestudio.waffleoverflow.domain.question.exception
 import com.wafflestudio.waffleoverflow.global.common.exception.DataNotFoundException
 import com.wafflestudio.waffleoverflow.global.common.exception.ErrorType
 
-class QuestionNotFoundException(detail: String) : DataNotFoundException(errorType = ErrorType.DATA_NOT_FOUND, detail)
+class QuestionNotFoundException(detail: String) :
+    DataNotFoundException(errorType = ErrorType.DATA_NOT_FOUND, detail)

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
@@ -71,7 +71,7 @@ class QuestionService(
         answer: Answer
     ): QuestionDto.Response {
         validateUser(user, question)
-        answer.accepted = true
+        answer.accepted = !answer.accepted
         return QuestionDto.Response(question)
     }
 

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
@@ -70,18 +70,15 @@ class QuestionService(
 
     fun acceptAnswer(
         user: User,
-        questionId: Long,
-        answerId: Long,
+        question: Question,
+        answer: Answer,
     ): QuestionDto.Response {
-        val question = findById(questionId)
-        val answer = answerService.findById(answerId)
-
         validateUser(user, question)
         if (!answer.accepted && checkAcceptedAnswerExists(question)) {
             throw AcceptedAnswerExistsException("Accepted answer already exists")
         }
 
-        answer.accepted = true
+        answer.accepted = !answer.accepted
         return QuestionDto.Response(question)
     }
 

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
@@ -72,7 +72,7 @@ class QuestionService(
     fun acceptAnswer(
         user: User,
         question: Question,
-        answer: Answer,
+        answer: Answer
     ): QuestionDto.Response {
         validateUser(user, question)
         if (!checkAnswerIsUnderQuestion(question, answer)) {

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.waffleoverflow.domain.answer.repository.AnswerRepository
 import com.wafflestudio.waffleoverflow.domain.answer.service.AnswerService
 import com.wafflestudio.waffleoverflow.domain.question.dto.QuestionDto
 import com.wafflestudio.waffleoverflow.domain.question.exception.AcceptedAnswerExistsException
+import com.wafflestudio.waffleoverflow.domain.question.exception.AnswerIsNotUnderQuestionException
 import com.wafflestudio.waffleoverflow.domain.question.exception.QuestionNotFoundException
 import com.wafflestudio.waffleoverflow.domain.question.exception.UnauthorizedQuestionEditException
 import com.wafflestudio.waffleoverflow.domain.question.model.Question
@@ -74,6 +75,10 @@ class QuestionService(
         answer: Answer,
     ): QuestionDto.Response {
         validateUser(user, question)
+        if (!checkAnswerIsUnderQuestion(question, answer)) {
+            throw AnswerIsNotUnderQuestionException("Answer does not belong to the question")
+        }
+
         if (!answer.accepted && checkAcceptedAnswerExists(question)) {
             throw AcceptedAnswerExistsException("Accepted answer already exists")
         }
@@ -94,5 +99,12 @@ class QuestionService(
         question: Question
     ): Boolean {
         return question.answers.any { it.accepted }
+    }
+
+    private fun checkAnswerIsUnderQuestion(
+        question: Question,
+        answer: Answer
+    ): Boolean {
+        return question.answers.any { it.id == answer.id }
     }
 }


### PR DESCRIPTION
- 채택 취소 기능을 추가하였습니다.
  - 기존의 채택된 answer에 다시 똑같은 API를 보내면 됩니다.

- 중복 채택 방지 로직을 추가하였습니다.
  - 이미 채택된 답변이 있는 상태에서 다른 답변을 채택하면 오류를 내보냅니다.
  - 사실 이미 프론트에서는 이미 채택된 답변이 있다면 다른 답변에는 채택 버튼을 누를 수 없게 만들어서, 중복 안전장치입니다.

- 답변이 해당 질문의 소유하에 있는지 확인하는 로직을 추가하였습니다.
  - 포스트맨으로 API를 테스트 할 때, 질문의 주인인 것만 확인이 되면 임의의 답변을 채택할 수 있는 허점을 발견하여 수정하였습니다. 
  - 프론트에서는 해당 질문에 달린 답변만 채택하는 버튼이 있기에 상관이 없었습니다.
  
  