### PR TITLE
Fix/minor issues

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/model/Comment.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.waffleoverflow.domain.answer.model.Answer
 import com.wafflestudio.waffleoverflow.domain.model.BaseTimeEntity
 import com.wafflestudio.waffleoverflow.domain.question.model.Question
 import com.wafflestudio.waffleoverflow.domain.user.model.User
+import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.ManyToOne
@@ -17,6 +18,7 @@ class Comment(
     val user: User,
 
     @NotBlank
+    @Column(columnDefinition = "LONGTEXT")
     var body: String,
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = [])

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/service/CommentService.kt
@@ -81,8 +81,8 @@ class CommentService(
     private fun checkCommentLength(
         body: String
     ) {
-        if (body.length >= 250) {
-            throw TooLongCommentException("Comment is longer than 250 characters")
+        if (body.length > 600) {
+            throw TooLongCommentException("Comment length exceeds 600 characters")
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
@@ -61,6 +61,9 @@ class UserDto {
     )
 
     data class EditProfileRequest(
+        @field:NotBlank
+        val displayName: String, // same as username is User model
+
         val location: String?,
         val userTitle: String?,
         val aboutMe: String?,

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/model/User.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/model/User.kt
@@ -6,7 +6,6 @@ import com.wafflestudio.waffleoverflow.domain.model.BaseEntity
 import com.wafflestudio.waffleoverflow.domain.question.model.Question
 import com.wafflestudio.waffleoverflow.domain.vote.model.Vote
 import com.wafflestudio.waffleoverflow.domain.comment.model.Comment
-import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.FetchType
@@ -46,15 +45,15 @@ class User(
 
     var githubLink: String? = null,
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [])
     var questions: MutableList<Question> = mutableListOf(),
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [])
     var answers: MutableList<Answer> = mutableListOf(),
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [])
     var votes: MutableList<Vote> = mutableListOf(),
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [])
     var comments: MutableList<Comment> = mutableListOf(),
 ) : BaseEntity()

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.waffleoverflow.domain.user.service
 
 import com.wafflestudio.waffleoverflow.domain.user.dto.UserDto
 import com.wafflestudio.waffleoverflow.domain.user.exception.BadGrantTypeException
-import com.wafflestudio.waffleoverflow.domain.user.exception.EmptyRequestException
 import com.wafflestudio.waffleoverflow.domain.user.exception.InvalidEmailFormatException
 import com.wafflestudio.waffleoverflow.domain.user.exception.InvalidPasswordFormatException
 import com.wafflestudio.waffleoverflow.domain.user.exception.TooLongUsernameException
@@ -107,19 +106,19 @@ class UserService(
         user: User,
         editProfileRequest: UserDto.EditProfileRequest,
     ): User {
+        val displayName = editProfileRequest.displayName
         val location = editProfileRequest.location
         val userTitle = editProfileRequest.userTitle
         val aboutMe = editProfileRequest.aboutMe
         val websiteLink = editProfileRequest.websiteLink
         val githubLink = editProfileRequest.githubLink
 
-        if (location == null &&
-            userTitle == null &&
-            aboutMe == null &&
-            websiteLink == null &&
-            githubLink == null
-        ) throw EmptyRequestException("Empty request.")
+        if (!checkUsernameLength(editProfileRequest.displayName))
+            throw TooLongUsernameException()
+        if (userRepository.existsUserByUsername(editProfileRequest.displayName))
+            throw throw UserAlreadyExistsException()
 
+        user.username = displayName
         if (location != null) user.location = location
         if (userTitle != null) user.userTitle = userTitle
         if (aboutMe != null) user.aboutMe = aboutMe


### PR DESCRIPTION
회의 때 얘기했던 자잘한 이슈들 수정하였습니다.
- display name 변경 가능하게 하고, 중복 닉네임 체크
  - 비어 있는 경우, 너무 긴 경우도 검사하도록 하였습니다.
- 계정 삭제 계정만 없어지도록 (게시물은 남기기)
  - cascade type을 삭제하였습니다.
- Comment type longtext로 바꾸고 600자로 제한
  - stackoverflow가 600자 제한인 것 같아서 따라했습니다.