### PR TITLE
fix: add 'editedAt' field to Question model

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/dto/QuestionDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/dto/QuestionDto.kt
@@ -20,7 +20,7 @@ class QuestionDto {
         val tags: List<TagDto.Response>,
         val answers: List<AnswerDto.Response>,
         val createdAt: LocalDateTime,
-        val updatedAt: LocalDateTime
+        val editedAt: LocalDateTime
     ) {
         constructor(question: Question) : this(
             question.id,
@@ -32,7 +32,7 @@ class QuestionDto {
             question.questionTags.map { TagDto.Response(it.tag) },
             question.answers.map { AnswerDto.Response(it) },
             question.createdAt!!,
-            question.updatedAt!!
+            question.editedAt
         )
     }
 

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/model/Question.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/model/Question.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.waffleoverflow.domain.comment.model.Comment
 import com.wafflestudio.waffleoverflow.domain.model.BaseTimeEntity
 import com.wafflestudio.waffleoverflow.domain.user.model.User
 import com.wafflestudio.waffleoverflow.domain.vote.model.Vote
+import java.time.LocalDateTime
 import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -39,4 +40,6 @@ class Question(
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     var questionTags: MutableList<QuestionTag> = mutableListOf(),
+
+    var editedAt: LocalDateTime = LocalDateTime.now(),
 ) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/service/QuestionService.kt
@@ -15,6 +15,7 @@ import com.wafflestudio.waffleoverflow.domain.user.model.User
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 @Transactional
@@ -46,6 +47,7 @@ class QuestionService(
 
         question.title = requestBody.title
         question.body = requestBody.body
+        question.editedAt = LocalDateTime.now()
 
         questionRepository.save(question)
         return question


### PR DESCRIPTION
- 글 수정 뿐만 아니라 투표를 했을 때도 updatedAt이 변경되는 문제가 있었습니다.

- 여러 방법을 고민해보았는데, 필드를 하나 더 추가하는 것이 가장 좋은 방법인 것 같아서 이렇게 구현하였습니다.

- Question은 이제 기존의 updatedAt이 아닌 editedAt 이라는 이름으로 변경된 날짜를 관리하면 될 것 같습니다.