### PR TITLE
Feat/user list api

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/answer/dto/AnswerDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/answer/dto/AnswerDto.kt
@@ -15,7 +15,7 @@ class AnswerDto {
 
     data class Response(
         val id: Long,
-        val user: UserDto.ResponseSummary,
+        val user: UserDto.SimpleResponse,
         val body: String,
         val votes: Int,
         val comments: List<CommentDto.Response>,
@@ -25,7 +25,7 @@ class AnswerDto {
     ) {
         constructor(answer: Answer) : this(
             answer.id,
-            UserDto.ResponseSummary(answer.user),
+            UserDto.SimpleResponse(answer.user),
             answer.body,
             answer.votes.count { it.status == VoteStatus.UP } - answer.votes.count { it.status == VoteStatus.DOWN },
             answer.comments.map { CommentDto.Response(it) },

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/dto/CommentDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/comment/dto/CommentDto.kt
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotBlank
 class CommentDto {
     data class Response(
         val id: Long,
-        val user: UserDto.ResponseSummary,
+        val user: UserDto.SimpleResponse,
         val body: String,
         val questionId: Long?,
         val answerId: Long?,
@@ -17,7 +17,7 @@ class CommentDto {
     ) {
         constructor(comment: Comment) : this(
             comment.id,
-            UserDto.ResponseSummary(comment.user),
+            UserDto.SimpleResponse(comment.user),
             comment.body,
             comment.question?.id,
             comment.answer?.id,

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/dto/QuestionDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/dto/QuestionDto.kt
@@ -12,7 +12,7 @@ import javax.validation.constraints.NotBlank
 class QuestionDto {
     data class Response(
         val id: Long,
-        val user: UserDto.ResponseSummary,
+        val user: UserDto.SimpleResponse,
         val title: String,
         val body: String,
         val vote: Int,
@@ -24,7 +24,7 @@ class QuestionDto {
     ) {
         constructor(question: Question) : this(
             question.id,
-            UserDto.ResponseSummary(question.user),
+            UserDto.SimpleResponse(question.user),
             question.title,
             question.body,
             question.votes.count { it.status == VoteStatus.UP } - question.votes.count { it.status == VoteStatus.DOWN },

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/api/UserController.kt
@@ -2,8 +2,12 @@ package com.wafflestudio.waffleoverflow.domain.user.api
 
 import com.wafflestudio.waffleoverflow.domain.user.dto.UserDto
 import com.wafflestudio.waffleoverflow.domain.user.model.User
+import com.wafflestudio.waffleoverflow.domain.user.repository.UserRepository
 import com.wafflestudio.waffleoverflow.domain.user.service.UserService
 import com.wafflestudio.waffleoverflow.global.auth.CurrentUser
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
@@ -28,7 +32,17 @@ import javax.validation.Valid
 @RequestMapping("/api/user")
 class UserController(
     private val userService: UserService,
+    private val userRepository: UserRepository
 ) {
+    @GetMapping("/")
+    @ResponseStatus(HttpStatus.OK)
+    fun getUsers(
+        @PageableDefault(size = 36)
+        pageable: Pageable
+    ): Page<UserDto.CardResponse> {
+        return userRepository.findAll(pageable).map { UserDto.CardResponse(it) }
+    }
+
     @PostMapping("/signup/")
     @ResponseStatus(HttpStatus.OK)
     fun signup(

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
@@ -36,7 +36,7 @@ class UserDto {
         )
     }
 
-    data class ResponseSummary(
+    data class SimpleResponse(
         val id: Long,
         val username: String
     ) {

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
@@ -36,6 +36,22 @@ class UserDto {
         )
     }
 
+    data class CardResponse(
+        val id: Long,
+        val username: String,
+        val location: String?,
+        val questionCount: Int,
+        val answerCount: Int,
+    ) {
+        constructor(user: User) : this(
+            id = user.id,
+            username = user.username,
+            location = user.location,
+            questionCount = user.questions.count(),
+            answerCount = user.answers.count(),
+        )
+    }
+
     data class SimpleResponse(
         val id: Long,
         val username: String

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/vote/dto/VoteDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/vote/dto/VoteDto.kt
@@ -12,14 +12,14 @@ class VoteDto {
 
     data class Response(
         val id: Long,
-        val user: UserDto.ResponseSummary,
+        val user: UserDto.SimpleResponse,
         val status: String,
         val questionId: Long?,
         val answerId: Long?,
     ) {
         constructor(vote: Vote) : this(
             vote.id,
-            UserDto.ResponseSummary(vote.user),
+            UserDto.SimpleResponse(vote.user),
             vote.status.toString(),
             vote.question?.id,
             vote.answer?.id,


### PR DESCRIPTION
구현
- 사용자 목록을 가져오는 `GET api/user/` 를 구현했습니다.
  - 한번에 36개씩 가져오게 됩니다.
  - 정렬 기준 관려하여 나중에 추가 구현이 있을 수 있습니다.
- UserDto에 CardResponse를 추가했습니다.

수정
- UserDto의 ResponseSummary를 SimpleResponse로 이름을 변경했습니다. 