### PR TITLE
Hotfix/s3 : List to Set

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/model/Question.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/question/model/Question.kt
@@ -22,7 +22,7 @@ class Question(
     val user: User,
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
-    var answers: MutableList<Answer> = mutableListOf(),
+    var answers: MutableSet<Answer> = mutableSetOf(),
 
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = [CascadeType.REMOVE])
     var votes: MutableList<Vote> = mutableListOf(),

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/model/User.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/model/User.kt
@@ -45,11 +45,11 @@ class User(
 
     var githubLink: String? = null,
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [])
-    var questions: MutableList<Question> = mutableListOf(),
+    @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = [])
+    var questions: MutableSet<Question> = mutableSetOf(),
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [])
-    var answers: MutableList<Answer> = mutableListOf(),
+    @OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = [])
+    var answers: MutableSet<Answer> = mutableSetOf(),
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [])
     var votes: MutableList<Vote> = mutableListOf(),

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/util/S3Utils.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/util/S3Utils.kt
@@ -5,7 +5,6 @@ import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest
 import com.amazonaws.util.IOUtils
@@ -59,7 +58,6 @@ class S3Utils {
 
         amazonS3.putObject(
             PutObjectRequest(bucket, dir + fileName, byteArrayIs, objMeta)
-                .withCannedAcl(CannedAccessControlList.PublicRead)
         )
 
         return amazonS3.getUrl(bucket, dir + fileName).toString()


### PR DESCRIPTION
- S3관련 함수 제거하였습니다.

### 중요한 부분입니다!!!
- failed lazy loading에 걸려서 `User`와 연관된 `Question` `Answer`를 Eager로 변경하였습니다.
  - User의 Question과 Answer는 추후 쿼리를 통해 변경할 수 있을 듯 합니다.
- 하나의 Entity에서 두 개 이상의 `EAGER loading`을 불러오게 되면 `cannot simultaneously fetch multiple bags`라는 에러메세지를 만날 수 있습니다.
- 이를 해결할 수 있는 가장 빠른 방법은 List타입을 Set 타입으로 바꾸는 것입니다. 그래서 현재는 User와 연관된 Question과 Answer 부분에만 List를 Set으로 적용해두었습니다.