### PR TITLE
Feature/s3delete

### DIFF
--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/dto/UserDto.kt
@@ -25,7 +25,7 @@ class UserDto {
             email = user.email,
             username = user.username,
             accessToken = user.accessToken,
-            image = user.s3Path,
+            image = user.s3ObjectKey,
             questions = user.questions.map { QuestionDto.ResponseSummary(it) },
             answers = user.answers.map { AnswerDto.ResponseSummary(it) },
             location = user.location,
@@ -48,7 +48,7 @@ class UserDto {
             id = user.id,
             username = user.username,
             location = user.location,
-            image = user.s3Path,
+            image = user.s3ObjectKey,
             questionCount = user.questions.count(),
             answerCount = user.answers.count(),
         )
@@ -62,7 +62,7 @@ class UserDto {
         constructor(user: User) : this(
             id = user.id,
             username = user.username,
-            image = user.s3Path,
+            image = user.s3ObjectKey,
         )
     }
 

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/model/User.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/model/User.kt
@@ -44,7 +44,7 @@ class User(
     @field:NotBlank
     var accessToken: String,
 
-    var s3Path: String? = null,
+    var s3ObjectKey: String? = null,
 
     var location: String? = null,
 

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/service/UserService.kt
@@ -77,7 +77,7 @@ class UserService(
 
         user.username = randomName
         user.email = randomEmail
-        user.s3Path = null
+        user.s3ObjectKey = null
         user.location = null
         user.userTitle = null
         user.aboutMe = null
@@ -114,8 +114,11 @@ class UserService(
         user: User,
         multipartFile: MultipartFile
     ): User {
-        val urlPath = s3Utils.upload(multipartFile)
-        user.s3Path = urlPath.substring(62)
+        user.s3ObjectKey?.let {
+            s3Utils.delete(user.s3ObjectKey)
+        }
+
+        user.s3ObjectKey = s3Utils.upload(multipartFile)
 
         userRepository.save(user)
         return user

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/util/S3Utils.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/util/S3Utils.kt
@@ -62,4 +62,8 @@ class S3Utils {
 
         return amazonS3.getUrl(bucket, dir + fileName).toString()
     }
+
+    fun delete(key: String?) {
+        amazonS3.deleteObject(bucket, key)
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/util/S3Utils.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/util/S3Utils.kt
@@ -26,7 +26,6 @@ class AWSConfiguration {
     fun assetS3Client(
         @Value("\${aws.access-key}") accessKey: String,
         @Value("\${aws.secret-key}") secretKey: String,
-        @Value("\${aws.s3.endpoint}") s3Endpoint: String
     ): AmazonS3 {
         return AmazonS3ClientBuilder.standard()
             .withCredentials(AWSStaticCredentialsProvider(BasicAWSCredentials(accessKey, secretKey)))
@@ -55,12 +54,13 @@ class S3Utils {
         objMeta.contentLength = bytes.size.toLong()
 
         val byteArrayIs = ByteArrayInputStream(bytes)
+        val key = "$dir/$fileName"
 
         amazonS3.putObject(
-            PutObjectRequest(bucket, dir + fileName, byteArrayIs, objMeta)
+            PutObjectRequest(bucket, key, byteArrayIs, objMeta)
         )
 
-        return amazonS3.getUrl(bucket, dir + fileName).toString()
+        return key
     }
 
     fun delete(key: String?) {

--- a/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/util/S3Utils.kt
+++ b/src/main/kotlin/com/wafflestudio/waffleoverflow/domain/user/util/S3Utils.kt
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 import java.io.ByteArrayInputStream
 import java.io.IOException
-import java.util.UUID
 
 // from https://wave1994.tistory.com/131
 
@@ -47,7 +46,7 @@ class S3Utils {
 
     @Throws(IOException::class)
     fun upload(multipartFile: MultipartFile): String {
-        val fileName = UUID.randomUUID().toString() + "-" + multipartFile.originalFilename
+        val fileName = multipartFile.originalFilename
         val objMeta = ObjectMetadata()
 
         val bytes = IOUtils.toByteArray(multipartFile.inputStream)


### PR DESCRIPTION
1. 이미지를 변경하면 기존 버킷에서 이미지가 삭제되도록 추가하였습니다.  
2. S3 key의 random prefix를 삭제하였습니다.
  - 과거에는 성능 향상을 위해 넣어줬다고 하는데, 지금은 그렇지 않아도 된다고 합니다. [참고](https://aws.amazon.com/about-aws/whats-new/2018/07/amazon-s3-announces-increased-request-rate-performance/)
3. User에는 object key만 추가하기 때문에, `User.s3path`를 `User.s3ObjectKey`로 재명명하였습니다.